### PR TITLE
Upgrade to support ckan 2.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,14 +43,25 @@ On the command line do this:
 - `cd` to the ckan directory, e.g. `/usr/lib/ckan/default/src/ckan`
 - start the consumers:
 
-```
-paster --plugin=ckanext-oaipmh harvester gather_consumer &
-paster --plugin=ckanext-oaipmh harvester fetch_consumer &
+```bash
+# ckan >= 2.9
+ckan harvester gather-consumer
+ckan harvester fetch-consumer
+
+# ckan < 2.9
+paster --plugin=ckanext-oaipmh harvester gather_consumer
+paster --plugin=ckanext-oaipmh harvester fetch_consumer
 ```
 
 - run the job:
 
-    `paster --plugin=ckanext-oaipmh harvester run`
+```bash
+# ckan >= 2.9
+ckan harvester run
+
+# ckan < 2.9
+paster --plugin=ckanext-oaipmh harvester run
+```
 
 The harvester should now start and import the OAI-PMH metadata.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # CKAN Harvester for OAI-PMH
-
-[![Build Status](https://travis-ci.org/openresearchdata/ckanext-oaipmh.svg?branch=master)](https://travis-ci.org/openresearchdata/ckanext-oaipmh)
-
+## CKAN < 2.9 support
+As of `1.1.0` this extention has been made to work with CKAN 2.9. While attempts have been made to maintain compatibility with prior version of CKAN, there may be issues. If any issues are discovered we are happy to accept PRs. Alternatively for compatibility <2.9 the `1.0.0` tag can be used.
 ## Instructions
 
 ### Installation
@@ -10,7 +9,7 @@ Use `pip` to install this plugin. This example installs it in `/var/www`
 
 ```bash
 source /home/www-data/pyenv/bin/activate
-pip install -e git+https://github.com/openresearchdata/ckanext-oaipmh.git#egg=ckanext-oaipmh --src /var/www
+pip install -e git+https://github.com/mediasuitenz/ckanext-oaipmh.git#egg=ckanext-oaipmh --src /var/www
 cd /var/www/ckanext-oaipmh
 pip install -r requirements.txt
 python setup.py develop

--- a/ckanext/oaipmh/harvester.py
+++ b/ckanext/oaipmh/harvester.py
@@ -1,6 +1,8 @@
+from __future__ import absolute_import
+from builtins import str
 import logging
 import json
-import urllib2
+from six.moves import urllib as urllib
 import traceback
 
 from ckan.model import Session
@@ -15,8 +17,8 @@ from ckanext.harvest.model import HarvestObject
 import oaipmh.client
 from oaipmh.metadata import MetadataRegistry
 
-from metadata import oai_ddi_reader
-from metadata import oai_dc_reader
+from .metadata import oai_ddi_reader
+from .metadata import oai_dc_reader
 
 log = logging.getLogger(__name__)
 
@@ -74,7 +76,7 @@ class OaipmhHarvester(HarvesterBase):
                 harvest_obj_ids.append(harvest_obj.id)
                 log.info("Harvest obj %s created" % harvest_obj.id)
                 # return harvest_obj_ids # This is to get only one record
-        except urllib2.HTTPError, e:
+        except urllib.error.HTTPError as e:
             log.exception(
                 'Gather stage failed on %s (%s): %s, %s'
                 % (
@@ -89,7 +91,7 @@ class OaipmhHarvester(HarvesterBase):
                 harvest_job.source.url, harvest_job
             )
             return None
-        except Exception, e:
+        except Exception as e:
             log.exception(
                 'Gather stage failed on %s: %s'
                 % (
@@ -190,7 +192,7 @@ class OaipmhHarvester(HarvesterBase):
                 )
                 self._after_record_fetch(record)
                 log.info('record found!')
-            except:
+            except Exception:
                 log.exception('getRecord failed for %s' % harvest_object.guid)
                 self._save_object_error(
                     'Get record failed for %s!' % harvest_object.guid,
@@ -204,7 +206,7 @@ class OaipmhHarvester(HarvesterBase):
 
             try:
                 metadata_modified = header.datestamp().isoformat()
-            except:
+            except Exception:
                 metadata_modified = None
 
             try:
@@ -214,7 +216,7 @@ class OaipmhHarvester(HarvesterBase):
                     content_dict['metadata_modified'] = metadata_modified
                 log.warn(content_dict)
                 content = json.dumps(content_dict)
-            except:
+            except Exception:
                 log.exception('Dumping the metadata failed!')
                 self._save_object_error(
                     'Dumping the metadata failed!',
@@ -222,14 +224,15 @@ class OaipmhHarvester(HarvesterBase):
                 )
                 return False
             if self.set_filter:
-                if any(setSpecVal == self.set_filter for setSpecVal in content_dict['set_spec']):
+                if any(setSpecVal == self.set_filter
+                       for setSpecVal in content_dict['set_spec']):
                     harvest_object.content = content
                     harvest_object.save()
             else:
                 harvest_object.content = content
                 harvest_object.save()
 
-        except Exception, e:
+        except Exception as e:
             log.exception(e)
             self._save_object_error(
                 (
@@ -268,12 +271,14 @@ class OaipmhHarvester(HarvesterBase):
 
         if not harvest_object:
             log.error('No harvest object received')
-            self._save_object_error('No harvest object received', harvest_object)
+            self._save_object_error(
+                'No harvest object received', harvest_object)
             return False
 
         if not harvest_object.content:
             log.error('No harvest object received')
-            self._save_object_error('No harvest object received', harvest_object)
+            self._save_object_error(
+                'No harvest object received', harvest_object)
             return False
 
         try:
@@ -293,7 +298,7 @@ class OaipmhHarvester(HarvesterBase):
 
             mapping = self._get_mapping()
 
-            for ckan_field, oai_field in mapping.iteritems():
+            for ckan_field, oai_field in list(mapping.items()):
                 try:
                     package_dict[ckan_field] = content[oai_field][0]
                 except (IndexError, KeyError):
@@ -315,20 +320,9 @@ class OaipmhHarvester(HarvesterBase):
             package_dict['license'] = self._extract_license_id(content)
 
             # add resources
-            '''
-            # Kept this purposely as few things are out of box
-            url = self._get_possible_resource(harvest_object, content)
-            if url:
-                package_dict['resources'] = self._extract_resources(url, content)
-            else:
-                identifierContent = content.get('identifier')
-                package_dict['resources'] = []
-                for ident in identifierContent:
-                    package_dict['resources'].append({'name': ident, 'url':"https://doi.org/"+ident})
-                    break
-            '''
             package_dict['resources'] = []
-            package_dict['resources'].append({'name': 'Figshare', 'url': self._extract_relation(content)})
+            package_dict['resources'].append(
+                {'name': 'Figshare', 'url': self._extract_relation(content)})
 
             # extract tags from 'type' and 'subject' field
             # everything else is added as extra field
@@ -340,32 +334,15 @@ class OaipmhHarvester(HarvesterBase):
 
             package_dict['modified'] = content['metadata_modified']
             package_dict['issued'] = self._extract_created_date(content)
-            package_dict['source_identifier'] = self._extract_identifier(content)
+            package_dict['source_identifier'] = self._extract_identifier(
+                content)
 
             package_dict['identifier'] = self._extract_relation(content)
 
             package_dict['references'] = self._extract_relation(content)
 
-
             # groups aka projects
-
             groups = []
-            """ Disabled as part of DATA-725 support issue
-
-            # create group based on set
-            if content['set_spec']:
-                groups.extend(
-                    self._find_or_create_groups(
-                        content['set_spec'],
-                        context.copy()
-                    )
-                )
-
-            # add groups from content
-            groups.extend(
-                self._extract_groups(content, context.copy())
-            )
-            """
             package_dict['groups'] = groups
 
             # allow sub-classes to add additional fields
@@ -383,7 +360,7 @@ class OaipmhHarvester(HarvesterBase):
             Session.commit()
 
             log.info("Finished record")
-        except Exception, e:
+        except Exception as e:
             log.exception(e)
             self._save_object_error(
                 (
@@ -422,8 +399,8 @@ class OaipmhHarvester(HarvesterBase):
     def _extract_tags_and_extras(self, content):
         extras = []
         tags = []
-        for key, value in content.iteritems():
-            if key in self._get_mapping().values():
+        for key, value in list(content.items()):
+            if key in list(self._get_mapping().values()):
                 continue
             if key in ['type', 'subject']:
                 if type(value) is list:
@@ -502,7 +479,7 @@ class OaipmhHarvester(HarvesterBase):
             try:
                 group = get_action('group_show')(context.copy(), data_dict)
                 log.info('found the group ' + group['id'])
-            except:
+            except Exception:
                 group = get_action('group_create')(context.copy(), data_dict)
                 log.info('created the group ' + group['id'])
             group_ids.append(group['id'])

--- a/ckanext/oaipmh/harvester.py
+++ b/ckanext/oaipmh/harvester.py
@@ -1,8 +1,7 @@
-from __future__ import absolute_import
-from builtins import str
+from six import text_type
+from six.moves import urllib as urllib
 import logging
 import json
-from six.moves import urllib as urllib
 import traceback
 
 from ckan.model import Session
@@ -17,8 +16,8 @@ from ckanext.harvest.model import HarvestObject
 import oaipmh.client
 from oaipmh.metadata import MetadataRegistry
 
-from .metadata import oai_ddi_reader
-from .metadata import oai_dc_reader
+from ckanext.oaipmh.metadata import oai_ddi_reader
+from ckanext.oaipmh.metadata import oai_dc_reader
 
 log = logging.getLogger(__name__)
 

--- a/ckanext/oaipmh/metadata.py
+++ b/ckanext/oaipmh/metadata.py
@@ -45,7 +45,7 @@ oai_dc_reader = MetadataReader(
         'rights':           ('textList', 'oai_dc:dc/dc:rights/text()')  # noqa
     },
     namespaces={
-    'oai_dc': 'http://www.openarchives.org/OAI/2.0/oai_dc/',
-    'oai': 'http://www.openarchives.org/OAI/2.0/',
-    'dc': 'http://purl.org/dc/elements/1.1/'}
+        'oai_dc': 'http://www.openarchives.org/OAI/2.0/oai_dc/',
+        'oai': 'http://www.openarchives.org/OAI/2.0/',
+        'dc': 'http://purl.org/dc/elements/1.1/'}
 )

--- a/ckanext/oaipmh/tests/test_queue.py
+++ b/ckanext/oaipmh/tests/test_queue.py
@@ -1,12 +1,9 @@
-import os
 from ckanext.oaipmh.harvester import OaipmhHarvester
 import ckanext.harvest.model as harvest_model
-from ckanext.harvest.model import HarvestObject, HarvestObjectExtra
 import ckanext.harvest.queue as queue
-import json
 import ckan.logic as logic
 from ckan import model
-from pprint import pprint
+from builtins import object
 
 
 class TestOaipmhHarvester(OaipmhHarvester):
@@ -32,12 +29,12 @@ class TestHarvestQueue(object):
 
     def test_01_basic_harvester(self):
 
-        ### make sure queues/exchanges are created first and are empty
-        consumer = queue.get_consumer('ckan.harvest.gather','harvest_job_id')
-        consumer_fetch = queue.get_consumer('ckan.harvest.fetch','harvest_object_id')
+        # make sure queues/exchanges are created first and are empty
+        consumer = queue.get_consumer('ckan.harvest.gather', 'harvest_job_id')
+        consumer_fetch = queue.get_consumer(
+            'ckan.harvest.fetch', 'harvest_object_id')
         consumer.queue_purge(queue='ckan.harvest.gather')
         consumer_fetch.queue_purge(queue='ckan.harvest.fetch')
-
 
         user = logic.get_action('get_site_user')(
             {'model': model, 'ignore_auth': True}, {}
@@ -60,7 +57,7 @@ class TestHarvestQueue(object):
 
         harvest_job = logic.get_action('harvest_job_create')(
             context,
-            {'source_id':harvest_source['id']}
+            {'source_id': harvest_source['id']}
         )
 
         job_id = harvest_job['id']
@@ -71,7 +68,7 @@ class TestHarvestQueue(object):
 
         logic.get_action('harvest_jobs_run')(
             context,
-            {'source_id':harvest_source['id']}
+            {'source_id': harvest_source['id']}
         )
 
         assert logic.get_action('harvest_job_show')(

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,1 @@
+pytest-ckan==0.0.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@
 flake8==2.1.0
 pyoai==2.5.0
 mock==1.0.1
-nose==1.3.1
 coverage==3.7.1
 six==1.16.0
+python-dateutil==2.8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 # This file lists the dependencies of this extension.
 # Install with a command like: pip install -r requirements.txt 
 flake8==2.1.0
-pyoai==2.4.5
+pyoai==2.5.0
 mock==1.0.1
 nose==1.3.1
 coverage==3.7.1
+six==1.16.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,3 @@
-# This file lists the dependencies of this extension.
-# Install with a command like: pip install -r requirements.txt 
-flake8==2.1.0
-pyoai==2.5.0
-mock==1.0.1
-coverage==3.7.1
+git+https://github.com/infrae/pyoai.git@5f6eba1201270d930ed684e15e9b9fc885649d17
 six==1.16.0
 python-dateutil==2.8.2

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '1.0.0'
+version = '1.1.0'
 
 setup(
     name='ckanext-oaipmh',

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 from setuptools import setup, find_packages
-import sys, os
 
 version = '1.0.0'
 
@@ -8,7 +7,7 @@ setup(
     version=version,
     description="OAI-PMH Harvester for CKAN",
     long_description="",
-    classifiers=[], # Get strings from http://pypi.python.org/pypi?%3Aaction=list_classifiers
+    classifiers=[],
     keywords='',
     author='Liip AG',
     author_email='ogd@liip.ch',
@@ -21,9 +20,8 @@ setup(
     install_requires=[
         # -*- Extra requirements: -*-
     ],
-    entry_points=\
-    """
-    [ckan.plugins]
-    oaipmh_harvester=ckanext.oaipmh.harvester:OaipmhHarvester
-    """,
+    entry_points='''
+        [ckan.plugins]
+        oaipmh_harvester=ckanext.oaipmh.harvester:OaipmhHarvester
+    ''',
 )


### PR DESCRIPTION
- Adds `six` to manage the dependency on `urllib` between python 2 and 3.
- Test / readme still reference old `nose` framework that has been dropped by ckan core. 