### PR TITLE
SUPDATA-77 oaipmh fixes

### DIFF
--- a/ckanext/oaipmh/harvester.py
+++ b/ckanext/oaipmh/harvester.py
@@ -227,6 +227,12 @@ class OaipmhHarvester(HarvesterBase):
                        for setSpecVal in content_dict['set_spec']):
                     harvest_object.content = content
                     harvest_object.save()
+                else:
+                    log.info((
+                        'Skipping harvest due to filter configured: %s, set_spec is %s'
+                        % (self.set_filter, content_dict['set_spec'])
+                    ))
+                    return False
             else:
                 harvest_object.content = content
                 harvest_object.save()

--- a/ckanext/oaipmh/harvester.py
+++ b/ckanext/oaipmh/harvester.py
@@ -359,7 +359,8 @@ class OaipmhHarvester(HarvesterBase):
             log.info('Create/update package using dict: %s' % package_dict)
             self._create_or_update_package(
                 package_dict,
-                harvest_object
+                harvest_object,
+                'package_show'
             )
 
             Session.commit()

--- a/ckanext/oaipmh/harvester.py
+++ b/ckanext/oaipmh/harvester.py
@@ -428,9 +428,9 @@ class OaipmhHarvester(HarvesterBase):
                 except (ValueError, TypeError):
                     continue
 
-            extras.append((key, value))
+            extras.append({'key': key, 'value': value})
 
-        tags = [munge_tag(tag[:100]) for tag in tags]
+        tags = [{'name': munge_tag(tag[:100])} for tag in tags]
 
         return (tags, extras)
 


### PR DESCRIPTION
https://mediasuite.atlassian.net/browse/SUPDATA-77

Apparently this harvest has been failing for a long time, and I'm not surprised.

It seems that the tags and extras objects were throwing errors due to their structure being incorrect, and then the datasets were not getting created.

There were a large number of errors getting generated when the a custom `filters` configuration was applied and the object did not match the applied filter.

Also, the internals of ckan and the ckan-harvester plugin have changed in CKAN 2.8+, luckily someone had already solved that one: https://github.com/openresearchdata/ckanext-oaipmh/pull/24